### PR TITLE
Migrate to version 3.14 for best practices

### DIFF
--- a/dlss_updater/auto_updater.py
+++ b/dlss_updater/auto_updater.py
@@ -76,7 +76,7 @@ async def check_for_updates_async() -> tuple[str | None, bool, str | None]:
             logger.info("You have the latest version.")
             return latest_version, False, download_url
 
-    except asyncio.TimeoutError:
+    except TimeoutError:
         logger.error("Timeout checking for updates")
         return None, False, None
     except aiohttp.ClientError as e:

--- a/dlss_updater/backup_manager.py
+++ b/dlss_updater/backup_manager.py
@@ -10,7 +10,6 @@ import tempfile
 import asyncio
 import aiofiles
 from pathlib import Path
-from typing import Optional, Tuple, List, Dict
 
 from dlss_updater.logger import setup_logger
 from dlss_updater.database import db_manager
@@ -39,7 +38,7 @@ async def async_copy2(src: Path, dst: Path, chunk_size: int = 65536) -> None:
     await asyncio.to_thread(shutil.copystat, src, dst)
 
 
-def record_backup_metadata_sync(dll_path: Path, backup_path: Path) -> Optional[int]:
+def record_backup_metadata_sync(dll_path: Path, backup_path: Path) -> int | None:
     """
     Record backup metadata in database (synchronous version).
 
@@ -90,7 +89,7 @@ def record_backup_metadata_sync(dll_path: Path, backup_path: Path) -> Optional[i
         return None
 
 
-async def record_backup_metadata(dll_path: Path, backup_path: Path) -> Optional[int]:
+async def record_backup_metadata(dll_path: Path, backup_path: Path) -> int | None:
     """
     Record backup metadata in database (async version).
 
@@ -143,7 +142,7 @@ async def record_backup_metadata(dll_path: Path, backup_path: Path) -> Optional[
         return None
 
 
-async def restore_dll_from_backup(backup_id: int) -> Tuple[bool, str]:
+async def restore_dll_from_backup(backup_id: int) -> tuple[bool, str]:
     """
     Restore a DLL from backup
 
@@ -252,7 +251,7 @@ async def restore_dll_from_backup(backup_id: int) -> Tuple[bool, str]:
         return False, f"Unexpected error during restore: {str(e)}"
 
 
-async def delete_backup(backup_id: int) -> Tuple[bool, str]:
+async def delete_backup(backup_id: int) -> tuple[bool, str]:
     """
     Delete a backup file and mark it inactive in database
 
@@ -292,7 +291,7 @@ async def delete_backup(backup_id: int) -> Tuple[bool, str]:
         return False, f"Error deleting backup: {str(e)}"
 
 
-async def validate_backup(backup_id: int) -> Tuple[bool, str]:
+async def validate_backup(backup_id: int) -> tuple[bool, str]:
     """
     Validate that a backup file exists and is accessible
 
@@ -336,9 +335,9 @@ async def validate_backup(backup_id: int) -> Tuple[bool, str]:
 
 
 async def validate_backups_batch(
-    backup_ids: List[int],
+    backup_ids: list[int],
     max_concurrent: int = None
-) -> dict[int, Tuple[bool, str]]:
+) -> dict[int, tuple[bool, str]]:
     """
     Validate multiple backups in parallel with maximum concurrency.
 
@@ -357,7 +356,7 @@ async def validate_backups_batch(
     # Maximum concurrency for backup validation (async file I/O scales extremely well)
     semaphore = asyncio.Semaphore(max_concurrent)
 
-    async def bounded_validate(backup_id: int) -> Tuple[int, Tuple[bool, str]]:
+    async def bounded_validate(backup_id: int) -> tuple[int, tuple[bool, str]]:
         async with semaphore:
             result = await validate_backup(backup_id)
             return backup_id, result
@@ -372,7 +371,7 @@ async def validate_backups_batch(
 async def restore_group_for_game(
     game_id: int,
     group: str,  # "all" or specific group name like "DLSS"
-) -> Tuple[bool, str, List[Dict[str, str]]]:
+) -> tuple[bool, str, list[dict[str, str]]]:
     """
     Restore all backups for a game, optionally filtered by DLL group.
 
@@ -414,7 +413,7 @@ async def restore_group_for_game(
         # This prevents overwhelming the filesystem while still achieving parallelism
         semaphore = asyncio.Semaphore(Concurrency.IO_HEAVY)
 
-        async def bounded_restore(backup) -> Dict[str, str]:
+        async def bounded_restore(backup) -> dict[str, str]:
             """Perform a single restore operation with semaphore-bounded concurrency."""
             async with semaphore:
                 success, message = await restore_dll_from_backup(backup.id)

--- a/dlss_updater/cache_manager.py
+++ b/dlss_updater/cache_manager.py
@@ -24,7 +24,6 @@ import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Dict, Optional, Set
 
 import aiofiles
 
@@ -94,8 +93,8 @@ class CacheStats:
     total_entries: int
     total_size_bytes: int
     memory_mapped_count: int
-    oldest_entry: Optional[datetime]
-    newest_entry: Optional[datetime]
+    oldest_entry: datetime | None
+    newest_entry: datetime | None
     evictions_performed: int
     cleanup_runs: int
 
@@ -106,7 +105,7 @@ class _RegisteredCache:
     name: str
     cache_dir: Path
     policy: CachePolicy
-    entries: Dict[str, CacheEntry] = field(default_factory=dict)
+    entries: dict[str, CacheEntry] = field(default_factory=dict)
     evictions_performed: int = 0
     cleanup_runs: int = 0
 
@@ -189,13 +188,13 @@ class UnifiedCacheManager:
         self._mmap_lock = asyncio.Lock()
 
         # Registered caches: name -> _RegisteredCache
-        self._caches: Dict[str, _RegisteredCache] = {}
+        self._caches: dict[str, _RegisteredCache] = {}
 
         # Memory-mapped files: path_str -> MmapHandle
-        self._mmaps: Dict[str, MmapHandle] = {}
+        self._mmaps: dict[str, MmapHandle] = {}
 
         # Background task handle
-        self._cleanup_task: Optional[asyncio.Task] = None
+        self._cleanup_task: asyncio.Task | None = None
         self._running = False
 
         # Global stats
@@ -212,7 +211,7 @@ class UnifiedCacheManager:
         self,
         name: str,
         cache_dir: Path,
-        policy: Optional[CachePolicy] = None
+        policy: CachePolicy | None = None
     ) -> None:
         """
         Register a cache directory with the manager.
@@ -572,7 +571,7 @@ class UnifiedCacheManager:
     # Cleanup and Eviction
     # =========================================================================
 
-    async def cleanup(self, cache_name: Optional[str] = None) -> int:
+    async def cleanup(self, cache_name: str | None = None) -> int:
         """
         Run cleanup/eviction on caches.
 
@@ -635,7 +634,7 @@ class UnifiedCacheManager:
             cache = self._caches[name]
             entries = cache.entries
             evicted_count = 0
-            to_remove: Set[str] = set()
+            to_remove: set[str] = set()
 
             now = datetime.now()
 
@@ -693,7 +692,7 @@ class UnifiedCacheManager:
     # Statistics
     # =========================================================================
 
-    async def get_stats(self) -> Dict[str, CacheStats]:
+    async def get_stats(self) -> dict[str, CacheStats]:
         """
         Get statistics for all registered caches.
 
@@ -727,7 +726,7 @@ class UnifiedCacheManager:
 
             return stats
 
-    async def get_global_stats(self) -> Dict[str, int]:
+    async def get_global_stats(self) -> dict[str, int]:
         """
         Get global cache manager statistics.
 

--- a/dlss_updater/database.py
+++ b/dlss_updater/database.py
@@ -13,7 +13,7 @@ import asyncio
 import logging
 import threading
 from pathlib import Path
-from typing import Optional, List, Dict, Tuple, Any
+from typing import Any
 from contextlib import asynccontextmanager
 from datetime import datetime
 
@@ -53,10 +53,10 @@ class DatabaseManager:
             self.initialized = False
 
             # Connection pool for async operations (aiosqlite)
-            self._async_pool: List[Any] = []  # List of aiosqlite.Connection
+            self._async_pool: list[Any] = []  # List of aiosqlite.Connection
             self._pool_size = 5
             self._pool_lock = asyncio.Lock()
-            self._pool_semaphore: Optional[asyncio.Semaphore] = None
+            self._pool_semaphore: asyncio.Semaphore | None = None
             self._pool_active = False  # Track pool lifecycle state
 
             # Thread-local storage for sync operations (connection reuse)
@@ -355,11 +355,11 @@ class DatabaseManager:
 
     # ===== Game Operations =====
 
-    async def upsert_game(self, game_data: Dict[str, Any]) -> Optional[Game]:
+    async def upsert_game(self, game_data: dict[str, Any]) -> Game | None:
         """Insert or update game record"""
         return await asyncio.to_thread(self._upsert_game, game_data)
 
-    def _upsert_game(self, game_data: Dict[str, Any]) -> Optional[Game]:
+    def _upsert_game(self, game_data: dict[str, Any]) -> Game | None:
         """Upsert game (runs in thread) - uses thread-local connection"""
         conn = self._get_thread_connection()
         cursor = conn.cursor()
@@ -401,11 +401,11 @@ class DatabaseManager:
             return None
         # Note: Don't close thread-local connection - it's reused
 
-    async def get_games_grouped_by_launcher(self) -> Dict[str, List[Game]]:
+    async def get_games_grouped_by_launcher(self) -> dict[str, list[Game]]:
         """Get all games grouped by launcher"""
         return await asyncio.to_thread(self._get_games_grouped_by_launcher)
 
-    def _get_games_grouped_by_launcher(self) -> Dict[str, List[Game]]:
+    def _get_games_grouped_by_launcher(self) -> dict[str, list[Game]]:
         """Get games grouped by launcher (runs in thread) - uses thread-local connection"""
         conn = self._get_thread_connection()
         cursor = conn.cursor()
@@ -566,11 +566,11 @@ class DatabaseManager:
 
     # ===== GameDLL Operations =====
 
-    async def upsert_game_dll(self, dll_data: Dict[str, Any]) -> Optional[GameDLL]:
+    async def upsert_game_dll(self, dll_data: dict[str, Any]) -> GameDLL | None:
         """Insert or update game DLL record"""
         return await asyncio.to_thread(self._upsert_game_dll, dll_data)
 
-    def _upsert_game_dll(self, dll_data: Dict[str, Any]) -> Optional[GameDLL]:
+    def _upsert_game_dll(self, dll_data: dict[str, Any]) -> GameDLL | None:
         """Upsert game DLL (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -616,11 +616,11 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def get_game_dll_by_path(self, dll_path: str) -> Optional[GameDLL]:
+    async def get_game_dll_by_path(self, dll_path: str) -> GameDLL | None:
         """Get game DLL by path"""
         return await asyncio.to_thread(self._get_game_dll_by_path, dll_path)
 
-    def _get_game_dll_by_path(self, dll_path: str) -> Optional[GameDLL]:
+    def _get_game_dll_by_path(self, dll_path: str) -> GameDLL | None:
         """Get game DLL by path (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -651,11 +651,11 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def get_dlls_for_game(self, game_id: int) -> List[GameDLL]:
+    async def get_dlls_for_game(self, game_id: int) -> list[GameDLL]:
         """Get all DLLs for a specific game"""
         return await asyncio.to_thread(self._get_dlls_for_game, game_id)
 
-    def _get_dlls_for_game(self, game_id: int) -> List[GameDLL]:
+    def _get_dlls_for_game(self, game_id: int) -> list[GameDLL]:
         """Get DLLs for game (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -687,11 +687,11 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def get_game_dll_by_path(self, dll_path: str) -> Optional[GameDLL]:
+    async def get_game_dll_by_path(self, dll_path: str) -> GameDLL | None:
         """Get DLL record by file path"""
         return await asyncio.to_thread(self._get_game_dll_by_path, dll_path)
 
-    def _get_game_dll_by_path(self, dll_path: str) -> Optional[GameDLL]:
+    def _get_game_dll_by_path(self, dll_path: str) -> GameDLL | None:
         """Get DLL by path (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -748,7 +748,7 @@ class DatabaseManager:
 
     # ===== Batch Operations (Performance Optimized) =====
 
-    async def batch_upsert_games(self, games: List[Dict[str, Any]]) -> Dict[str, Game]:
+    async def batch_upsert_games(self, games: list[dict[str, Any]]) -> dict[str, Game]:
         """
         Batch upsert multiple games in a single transaction.
 
@@ -766,7 +766,7 @@ class DatabaseManager:
 
         return await asyncio.to_thread(self._batch_upsert_games, games)
 
-    def _batch_upsert_games(self, games: List[Dict[str, Any]]) -> Dict[str, Game]:
+    def _batch_upsert_games(self, games: list[dict[str, Any]]) -> dict[str, Game]:
         """Batch upsert games (runs in thread) - uses thread-local connection"""
         conn = self._get_thread_connection()
         cursor = conn.cursor()
@@ -820,7 +820,7 @@ class DatabaseManager:
             conn.rollback()
             return {}
 
-    async def batch_upsert_dlls(self, dlls: List[Dict[str, Any]]) -> int:
+    async def batch_upsert_dlls(self, dlls: list[dict[str, Any]]) -> int:
         """
         Batch upsert multiple DLLs in a single transaction.
 
@@ -837,7 +837,7 @@ class DatabaseManager:
 
         return await asyncio.to_thread(self._batch_upsert_dlls, dlls)
 
-    def _batch_upsert_dlls(self, dlls: List[Dict[str, Any]]) -> int:
+    def _batch_upsert_dlls(self, dlls: list[dict[str, Any]]) -> int:
         """Batch upsert DLLs (runs in thread) - uses thread-local connection"""
         conn = self._get_thread_connection()
         cursor = conn.cursor()
@@ -871,11 +871,11 @@ class DatabaseManager:
 
     # ===== Backup Operations =====
 
-    async def insert_backup(self, backup_data: Dict[str, Any]) -> Optional[int]:
+    async def insert_backup(self, backup_data: dict[str, Any]) -> int | None:
         """Insert backup record"""
         return await asyncio.to_thread(self._insert_backup, backup_data)
 
-    def _insert_backup(self, backup_data: Dict[str, Any]) -> Optional[int]:
+    def _insert_backup(self, backup_data: dict[str, Any]) -> int | None:
         """Insert backup (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -903,11 +903,11 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def get_all_backups(self) -> List[DLLBackup]:
+    async def get_all_backups(self) -> list[DLLBackup]:
         """Get all active backups"""
         return await asyncio.to_thread(self._get_all_backups)
 
-    def _get_all_backups(self) -> List[DLLBackup]:
+    def _get_all_backups(self) -> list[DLLBackup]:
         """Get all backups (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -947,11 +947,11 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def get_backup_by_id(self, backup_id: int) -> Optional[DLLBackup]:
+    async def get_backup_by_id(self, backup_id: int) -> DLLBackup | None:
         """Get backup by ID"""
         return await asyncio.to_thread(self._get_backup_by_id, backup_id)
 
-    def _get_backup_by_id(self, backup_id: int) -> Optional[DLLBackup]:
+    def _get_backup_by_id(self, backup_id: int) -> DLLBackup | None:
         """Get backup by ID (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1124,11 +1124,11 @@ class DatabaseManager:
 
     # ===== Update History Operations =====
 
-    async def record_update_history(self, history_data: Dict[str, Any]):
+    async def record_update_history(self, history_data: dict[str, Any]):
         """Record update history"""
         return await asyncio.to_thread(self._record_update_history, history_data)
 
-    def _record_update_history(self, history_data: Dict[str, Any]):
+    def _record_update_history(self, history_data: dict[str, Any]):
         """Record update history (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1180,11 +1180,11 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def find_steam_app_by_name(self, game_name: str) -> Optional[int]:
+    async def find_steam_app_by_name(self, game_name: str) -> int | None:
         """Find Steam app ID by game name"""
         return await asyncio.to_thread(self._find_steam_app_by_name, game_name)
 
-    def _find_steam_app_by_name(self, game_name: str) -> Optional[int]:
+    def _find_steam_app_by_name(self, game_name: str) -> int | None:
         """Find Steam app by name (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1223,11 +1223,11 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def get_steam_app_list_timestamp(self) -> Optional[datetime]:
+    async def get_steam_app_list_timestamp(self) -> datetime | None:
         """Get timestamp of last Steam app list update"""
         return await asyncio.to_thread(self._get_steam_app_list_timestamp)
 
-    def _get_steam_app_list_timestamp(self) -> Optional[datetime]:
+    def _get_steam_app_list_timestamp(self) -> datetime | None:
         """Get Steam app list timestamp (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1279,11 +1279,11 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def get_cached_image_path(self, app_id: int) -> Optional[str]:
+    async def get_cached_image_path(self, app_id: int) -> str | None:
         """Get cached image path for Steam app"""
         return await asyncio.to_thread(self._get_cached_image_path, app_id)
 
-    def _get_cached_image_path(self, app_id: int) -> Optional[str]:
+    def _get_cached_image_path(self, app_id: int) -> str | None:
         """Get cached image path (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1380,7 +1380,7 @@ class DatabaseManager:
 
     # ===== Steam Apps FTS5 Operations (Phase 3) =====
 
-    async def upsert_steam_apps(self, apps: List[Tuple[int, str, str]]) -> int:
+    async def upsert_steam_apps(self, apps: list[tuple[int, str, str]]) -> int:
         """
         Bulk insert/update Steam apps with FTS5 indexing.
 
@@ -1400,7 +1400,7 @@ class DatabaseManager:
 
         return await asyncio.to_thread(self._upsert_steam_apps, apps)
 
-    def _upsert_steam_apps(self, apps: List[Tuple[int, str, str]]) -> int:
+    def _upsert_steam_apps(self, apps: list[tuple[int, str, str]]) -> int:
         """Bulk upsert Steam apps (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1437,7 +1437,7 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def search_steam_app(self, query: str, limit: int = 10) -> List[Tuple[int, str]]:
+    async def search_steam_app(self, query: str, limit: int = 10) -> list[tuple[int, str]]:
         """
         FTS5 full-text search for Steam apps by name.
 
@@ -1452,7 +1452,7 @@ class DatabaseManager:
         """
         return await asyncio.to_thread(self._search_steam_app, query, limit)
 
-    def _search_steam_app(self, query: str, limit: int) -> List[Tuple[int, str]]:
+    def _search_steam_app(self, query: str, limit: int) -> list[tuple[int, str]]:
         """FTS5 search for Steam app (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1512,7 +1512,7 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def get_steam_app_by_name(self, name_normalized: str) -> Optional[int]:
+    async def get_steam_app_by_name(self, name_normalized: str) -> int | None:
         """
         Exact match lookup for Steam app by normalized name.
 
@@ -1526,7 +1526,7 @@ class DatabaseManager:
         """
         return await asyncio.to_thread(self._get_steam_app_by_name, name_normalized)
 
-    def _get_steam_app_by_name(self, name_normalized: str) -> Optional[int]:
+    def _get_steam_app_by_name(self, name_normalized: str) -> int | None:
         """Get Steam app by normalized name (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1599,7 +1599,7 @@ class DatabaseManager:
 
     # ===== Per-Game Backup Operations =====
 
-    async def get_backups_for_game(self, game_id: int) -> List[GameDLLBackup]:
+    async def get_backups_for_game(self, game_id: int) -> list[GameDLLBackup]:
         """
         Get all active backups for a specific game.
 
@@ -1611,7 +1611,7 @@ class DatabaseManager:
         """
         return await asyncio.to_thread(self._get_backups_for_game, game_id)
 
-    def _get_backups_for_game(self, game_id: int) -> List[GameDLLBackup]:
+    def _get_backups_for_game(self, game_id: int) -> list[GameDLLBackup]:
         """Get backups for game (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1692,7 +1692,7 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def get_game_backup_summary(self, game_id: int) -> Optional[GameBackupSummary]:
+    async def get_game_backup_summary(self, game_id: int) -> GameBackupSummary | None:
         """
         Get summary of backups for a specific game.
 
@@ -1706,7 +1706,7 @@ class DatabaseManager:
         """
         return await asyncio.to_thread(self._get_game_backup_summary, game_id)
 
-    def _get_game_backup_summary(self, game_id: int) -> Optional[GameBackupSummary]:
+    def _get_game_backup_summary(self, game_id: int) -> GameBackupSummary | None:
         """Get game backup summary (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1759,7 +1759,7 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def get_backups_grouped_by_dll_type(self, game_id: int) -> Dict[str, List[DLLBackup]]:
+    async def get_backups_grouped_by_dll_type(self, game_id: int) -> dict[str, list[DLLBackup]]:
         """
         Get backups for a game grouped by DLL type.
 
@@ -1773,7 +1773,7 @@ class DatabaseManager:
         """
         return await asyncio.to_thread(self._get_backups_grouped_by_dll_type, game_id)
 
-    def _get_backups_grouped_by_dll_type(self, game_id: int) -> Dict[str, List[DLLBackup]]:
+    def _get_backups_grouped_by_dll_type(self, game_id: int) -> dict[str, list[DLLBackup]]:
         """Get backups grouped by DLL type (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1791,7 +1791,7 @@ class DatabaseManager:
                 ORDER BY gd.dll_type, b.backup_created_at DESC
             """, (game_id,))
 
-            grouped: Dict[str, List[DLLBackup]] = {}
+            grouped: dict[str, list[DLLBackup]] = {}
             for row in cursor.fetchall():
                 dll_type = row[9]
                 backup = DLLBackup(
@@ -1818,7 +1818,7 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def get_games_with_backups(self) -> List[GameWithBackupCount]:
+    async def get_games_with_backups(self) -> list[GameWithBackupCount]:
         """
         Get all games that have active backups with their backup counts.
 
@@ -1829,7 +1829,7 @@ class DatabaseManager:
         """
         return await asyncio.to_thread(self._get_games_with_backups)
 
-    def _get_games_with_backups(self) -> List[GameWithBackupCount]:
+    def _get_games_with_backups(self) -> list[GameWithBackupCount]:
         """Get games with backups (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1869,8 +1869,8 @@ class DatabaseManager:
 
     async def get_all_backups_filtered(
         self,
-        game_id: Optional[int] = None
-    ) -> List[GameDLLBackup]:
+        game_id: int | None = None
+    ) -> list[GameDLLBackup]:
         """
         Get all active backups, optionally filtered by game.
 
@@ -1884,8 +1884,8 @@ class DatabaseManager:
 
     def _get_all_backups_filtered(
         self,
-        game_id: Optional[int] = None
-    ) -> List[GameDLLBackup]:
+        game_id: int | None = None
+    ) -> list[GameDLLBackup]:
         """Get all backups with optional game filter (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1942,8 +1942,8 @@ class DatabaseManager:
 
     async def batch_check_games_have_backups(
         self,
-        game_ids: List[int]
-    ) -> Dict[int, bool]:
+        game_ids: list[int]
+    ) -> dict[int, bool]:
         """
         Check multiple games for backup existence in a single query.
 
@@ -1962,8 +1962,8 @@ class DatabaseManager:
 
     def _batch_check_games_have_backups(
         self,
-        game_ids: List[int]
-    ) -> Dict[int, bool]:
+        game_ids: list[int]
+    ) -> dict[int, bool]:
         """Batch check games for backups (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()
@@ -1998,9 +1998,9 @@ class DatabaseManager:
     async def search_games(
         self,
         query: str,
-        launcher: Optional[str] = None,
+        launcher: str | None = None,
         limit: int = 50
-    ) -> List[Game]:
+    ) -> list[Game]:
         """
         Search games by name using case-insensitive LIKE matching.
 
@@ -2020,9 +2020,9 @@ class DatabaseManager:
     def _search_games(
         self,
         query: str,
-        launcher: Optional[str],
+        launcher: str | None,
         limit: int
-    ) -> List[Game]:
+    ) -> list[Game]:
         """Search games (runs in thread) - uses thread-local connection"""
         conn = self._get_thread_connection()
         cursor = conn.cursor()
@@ -2100,7 +2100,7 @@ class DatabaseManager:
     async def add_search_history(
         self,
         query: str,
-        launcher: Optional[str] = None,
+        launcher: str | None = None,
         result_count: int = 0
     ):
         """
@@ -2120,7 +2120,7 @@ class DatabaseManager:
     def _add_search_history(
         self,
         query: str,
-        launcher: Optional[str],
+        launcher: str | None,
         result_count: int
     ):
         """Add search history (runs in thread)"""
@@ -2158,7 +2158,7 @@ class DatabaseManager:
         finally:
             conn.close()
 
-    async def get_search_history(self, limit: int = 10) -> List[Dict[str, Any]]:
+    async def get_search_history(self, limit: int = 10) -> list[dict[str, Any]]:
         """
         Get recent search history.
 
@@ -2170,7 +2170,7 @@ class DatabaseManager:
         """
         return await asyncio.to_thread(self._get_search_history, limit)
 
-    def _get_search_history(self, limit: int) -> List[Dict[str, Any]]:
+    def _get_search_history(self, limit: int) -> list[dict[str, Any]]:
         """Get search history (runs in thread)"""
         conn = sqlite3.connect(str(self.db_path))
         cursor = conn.cursor()

--- a/dlss_updater/linux_paths.py
+++ b/dlss_updater/linux_paths.py
@@ -7,7 +7,7 @@ import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import List, Optional, Dict, Tuple, Any
+from typing import Any
 
 logger = logging.getLogger("DLSSUpdater")
 
@@ -88,9 +88,9 @@ async def can_write_path_async(path: Path) -> bool:
 
 
 async def filter_accessible_paths(
-    paths: List[Path],
+    paths: list[Path],
     collect_skipped: bool = True
-) -> Tuple[List[Path], List[Dict[str, str]]]:
+) -> tuple[list[Path], list[dict[str, str]]]:
     """
     Filter paths to only those accessible by current user.
 
@@ -102,8 +102,8 @@ async def filter_accessible_paths(
         Tuple of (accessible_paths, skipped_info)
         skipped_info contains dicts with 'path', 'reason' keys
     """
-    accessible: List[Path] = []
-    skipped: List[Dict[str, str]] = []
+    accessible: list[Path] = []
+    skipped: list[dict[str, str]] = []
 
     for path in paths:
         if await can_write_path_async(path):
@@ -120,7 +120,7 @@ async def filter_accessible_paths(
     return accessible, skipped
 
 
-def get_linux_steam_path_sync() -> Optional[Path]:
+def get_linux_steam_path_sync() -> Path | None:
     """
     Detect native Steam installation on Linux (synchronous version).
 
@@ -134,7 +134,7 @@ def get_linux_steam_path_sync() -> Optional[Path]:
     return None
 
 
-async def get_linux_steam_path() -> Optional[Path]:
+async def get_linux_steam_path() -> Path | None:
     """
     Detect native Steam installation on Linux.
 
@@ -144,7 +144,7 @@ async def get_linux_steam_path() -> Optional[Path]:
     return await asyncio.to_thread(get_linux_steam_path_sync)
 
 
-async def get_linux_steam_libraries(steam_path: Path) -> List[Path]:
+async def get_linux_steam_libraries(steam_path: Path) -> list[Path]:
     """
     Get all Steam library folders on Linux.
     Parses libraryfolders.vdf (same format as Windows).
@@ -158,7 +158,7 @@ async def get_linux_steam_libraries(steam_path: Path) -> List[Path]:
     libraries = []
     library_file = steam_path / "steamapps" / "libraryfolders.vdf"
 
-    def _parse_libraries() -> List[Path]:
+    def _parse_libraries() -> list[Path]:
         result = []
         if not library_file.exists():
             return result
@@ -195,7 +195,7 @@ async def get_linux_steam_libraries(steam_path: Path) -> List[Path]:
     return libraries
 
 
-async def get_proton_prefixes(steam_path: Path) -> List[Path]:
+async def get_proton_prefixes(steam_path: Path) -> list[Path]:
     """
     Find all Proton prefix directories (Windows compatibility layers).
 
@@ -216,7 +216,7 @@ async def get_proton_prefixes(steam_path: Path) -> List[Path]:
     if not compatdata_base.exists():
         return prefixes
 
-    def _find_prefixes() -> List[Path]:
+    def _find_prefixes() -> list[Path]:
         result = []
         try:
             for app_dir in compatdata_base.iterdir():
@@ -238,7 +238,7 @@ async def get_proton_prefixes(steam_path: Path) -> List[Path]:
     return prefixes
 
 
-async def get_wine_prefixes() -> List[Path]:
+async def get_wine_prefixes() -> list[Path]:
     """
     Find Wine prefixes for non-Steam Windows launchers (Lutris, etc.).
 
@@ -251,7 +251,7 @@ async def get_wine_prefixes() -> List[Path]:
     """
     prefixes = []
 
-    def _find_wine_prefixes() -> List[Path]:
+    def _find_wine_prefixes() -> list[Path]:
         result = []
 
         # Standard Wine prefixes
@@ -289,7 +289,7 @@ async def get_wine_prefixes() -> List[Path]:
     return prefixes
 
 
-async def scan_proton_games(prefix: Path) -> List[Path]:
+async def scan_proton_games(prefix: Path) -> list[Path]:
     """
     Scan a Proton/Wine prefix for game directories containing DLLs.
 
@@ -306,7 +306,7 @@ async def scan_proton_games(prefix: Path) -> List[Path]:
         List of game directory paths.
     """
 
-    def _find_games() -> List[Path]:
+    def _find_games() -> list[Path]:
         result = []
         search_dirs = [
             prefix / "Program Files",
@@ -332,7 +332,7 @@ async def scan_proton_games(prefix: Path) -> List[Path]:
     return await asyncio.to_thread(_find_games)
 
 
-async def get_all_linux_game_paths() -> Dict[str, Any]:
+async def get_all_linux_game_paths() -> dict[str, Any]:
     """
     Get all game paths on Linux for scanning.
 
@@ -343,14 +343,14 @@ async def get_all_linux_game_paths() -> Dict[str, Any]:
         - 'wine': Wine prefix game directories
         - 'skipped_paths': List of paths skipped due to permissions
     """
-    result: Dict[str, Any] = {
+    result: dict[str, Any] = {
         'steam_native': [],
         'proton': [],
         'wine': [],
         'skipped_paths': [],
     }
 
-    all_skipped: List[Dict[str, str]] = []
+    all_skipped: list[dict[str, str]] = []
 
     # Native Steam
     steam_path = await get_linux_steam_path()
@@ -362,7 +362,7 @@ async def get_all_linux_game_paths() -> Dict[str, Any]:
 
         # Proton games within Steam
         proton_prefixes = await get_proton_prefixes(steam_path)
-        proton_games: List[Path] = []
+        proton_games: list[Path] = []
         for prefix in proton_prefixes:
             games = await scan_proton_games(prefix)
             proton_games.extend(games)
@@ -372,7 +372,7 @@ async def get_all_linux_game_paths() -> Dict[str, Any]:
 
     # Non-Steam Wine games
     wine_prefixes = await get_wine_prefixes()
-    wine_games: List[Path] = []
+    wine_games: list[Path] = []
     for prefix in wine_prefixes:
         games = await scan_proton_games(prefix)
         wine_games.extend(games)

--- a/dlss_updater/models.py
+++ b/dlss_updater/models.py
@@ -24,7 +24,6 @@ import msgspec
 # Maximum number of paths (sub-folders) allowed per launcher
 MAX_PATHS_PER_LAUNCHER = 5
 from datetime import datetime
-from typing import Optional, List, Dict
 
 
 # =============================================================================
@@ -130,7 +129,7 @@ class ScanCacheData(msgspec.Struct):
     Stores the mapping of launcher names to lists of DLL paths found during scan.
     Includes timestamp to track when the scan was performed.
     """
-    scan_results: Dict[str, List[str]]  # launcher -> DLL paths
+    scan_results: dict[str, list[str]]  # launcher -> DLL paths
     timestamp: str  # ISO format datetime string
 
     def __post_init__(self):
@@ -164,9 +163,9 @@ class UpdateResult(msgspec.Struct):
 
     Contains summary of what was updated, skipped, and any errors encountered.
     """
-    updated_games: List[str]
-    skipped_games: List[str]
-    errors: List[Dict[str, str]]
+    updated_games: list[str]
+    skipped_games: list[str]
+    errors: list[dict[str, str]]
     backup_created: bool
     total_processed: int
 
@@ -185,7 +184,7 @@ class Game(msgspec.Struct):
     name: str
     path: str
     launcher: str
-    steam_app_id: Optional[int] = None
+    steam_app_id: int | None = None
     last_scanned: datetime = msgspec.field(default_factory=datetime.now)
     created_at: datetime = msgspec.field(default_factory=datetime.now)
 
@@ -201,7 +200,7 @@ class GameDLL(msgspec.Struct):
     dll_type: str
     dll_filename: str
     dll_path: str
-    current_version: Optional[str] = None
+    current_version: str | None = None
     detected_at: datetime = msgspec.field(default_factory=datetime.now)
 
 
@@ -217,7 +216,7 @@ class DLLBackup(msgspec.Struct):
     dll_filename: str
     backup_path: str
     backup_size: int
-    original_version: Optional[str] = None
+    original_version: str | None = None
     backup_created_at: datetime = msgspec.field(default_factory=datetime.now)
     is_active: bool = True
 
@@ -237,7 +236,7 @@ class GameDLLBackup(msgspec.Struct):
     dll_filename: str
     backup_path: str
     backup_size: int
-    original_version: Optional[str] = None
+    original_version: str | None = None
     backup_created_at: datetime = msgspec.field(default_factory=datetime.now)
     is_active: bool = True
 
@@ -253,9 +252,9 @@ class GameBackupSummary(msgspec.Struct):
     game_name: str
     backup_count: int
     total_backup_size: int
-    dll_types: List[str]
-    oldest_backup: Optional[datetime] = None
-    newest_backup: Optional[datetime] = None
+    dll_types: list[str]
+    oldest_backup: datetime | None = None
+    newest_backup: datetime | None = None
 
 
 class GameWithBackupCount(msgspec.Struct):
@@ -279,8 +278,8 @@ class UpdateHistory(msgspec.Struct):
     id: int
     game_dll_id: int
     success: bool
-    from_version: Optional[str] = None
-    to_version: Optional[str] = None
+    from_version: str | None = None
+    to_version: str | None = None
     updated_at: datetime = msgspec.field(default_factory=datetime.now)
 
 
@@ -292,7 +291,7 @@ class SteamImage(msgspec.Struct):
     """
     steam_app_id: int
     image_url: str
-    local_path: Optional[str] = None
+    local_path: str | None = None
     cached_at: datetime = msgspec.field(default_factory=datetime.now)
     fetch_failed: bool = False
 
@@ -322,17 +321,17 @@ class LauncherPathsConfig(msgspec.Struct):
 
     Stores custom paths for each game launcher.
     """
-    steam_path: Optional[str] = None
-    ea_path: Optional[str] = None
-    epic_path: Optional[str] = None
-    gog_path: Optional[str] = None
-    ubisoft_path: Optional[str] = None
-    battle_net_path: Optional[str] = None
-    xbox_path: Optional[str] = None
-    custom_path_1: Optional[str] = None
-    custom_path_2: Optional[str] = None
-    custom_path_3: Optional[str] = None
-    custom_path_4: Optional[str] = None
+    steam_path: str | None = None
+    ea_path: str | None = None
+    epic_path: str | None = None
+    gog_path: str | None = None
+    ubisoft_path: str | None = None
+    battle_net_path: str | None = None
+    xbox_path: str | None = None
+    custom_path_1: str | None = None
+    custom_path_2: str | None = None
+    custom_path_3: str | None = None
+    custom_path_4: str | None = None
 
 
 class PerformanceConfig(msgspec.Struct):
@@ -360,7 +359,7 @@ class ProcessedDLLResult(msgspec.Struct):
     Returned by update_dll() function to indicate success/failure.
     """
     success: bool
-    backup_path: Optional[str] = None
+    backup_path: str | None = None
     dll_type: str = "Unknown"
 
 
@@ -373,8 +372,8 @@ class DLLDiscoveryResult(msgspec.Struct):
     dll_path: str
     launcher: str
     dll_type: str
-    current_version: Optional[str] = None
-    latest_version: Optional[str] = None
+    current_version: str | None = None
+    latest_version: str | None = None
     update_available: bool = False
 
 
@@ -402,7 +401,7 @@ class GameCardData(msgspec.Struct):
     """
     name: str
     path: str
-    dlls: List[DLLInfo]
+    dlls: list[DLLInfo]
 
 
 # =============================================================================
@@ -443,7 +442,7 @@ class BatchUpdateResult(msgspec.Struct):
     updates_skipped: int
     memory_peak_mb: float
     duration_seconds: float
-    errors: List[Dict[str, str]] = msgspec.field(default_factory=list)
+    errors: list[dict[str, str]] = msgspec.field(default_factory=list)
     # Detailed tracking: list of dicts with game_name, dll_name, old_version, new_version
-    detailed_updates: List[Dict[str, str]] = msgspec.field(default_factory=list)
-    detailed_skipped: List[Dict[str, str]] = msgspec.field(default_factory=list)
+    detailed_updates: list[dict[str, str]] = msgspec.field(default_factory=list)
+    detailed_skipped: list[dict[str, str]] = msgspec.field(default_factory=list)

--- a/dlss_updater/registry_utils.py
+++ b/dlss_updater/registry_utils.py
@@ -6,7 +6,6 @@ On non-Windows platforms, returns appropriate fallback values.
 
 import asyncio
 import logging
-from typing import Optional, Tuple
 
 from dlss_updater.platform_utils import IS_WINDOWS
 
@@ -18,12 +17,12 @@ DLSS_INDICATOR_KEY = "ShowDlssIndicator"
 DLSS_INDICATOR_ENABLED_VALUE = 0x00000400  # 1024 decimal
 
 
-async def get_dlss_overlay_state() -> Tuple[bool, Optional[str]]:
+async def get_dlss_overlay_state() -> tuple[bool, str | None]:
     """
     Read current DLSS debug overlay state from registry.
 
     Returns:
-        Tuple[bool, Optional[str]]: (is_enabled, error_message)
+        tuple[bool, str | None]: (is_enabled, error_message)
         - is_enabled: True if overlay is enabled, False otherwise
         - error_message: None on success, error string on failure
         - On Linux: Returns (False, "DLSS overlay is only available on Windows")
@@ -33,7 +32,7 @@ async def get_dlss_overlay_state() -> Tuple[bool, Optional[str]]:
     if not IS_WINDOWS:
         return (False, "DLSS overlay is only available on Windows")
 
-    def _read_registry() -> Tuple[bool, Optional[str]]:
+    def _read_registry() -> tuple[bool, str | None]:
         import winreg
 
         try:
@@ -59,7 +58,7 @@ async def get_dlss_overlay_state() -> Tuple[bool, Optional[str]]:
     return await asyncio.to_thread(_read_registry)
 
 
-async def set_dlss_overlay_state(enabled: bool) -> Tuple[bool, Optional[str]]:
+async def set_dlss_overlay_state(enabled: bool) -> tuple[bool, str | None]:
     """
     Set DLSS debug overlay state in registry.
 
@@ -67,7 +66,7 @@ async def set_dlss_overlay_state(enabled: bool) -> Tuple[bool, Optional[str]]:
         enabled: True to enable overlay, False to disable
 
     Returns:
-        Tuple[bool, Optional[str]]: (success, error_message)
+        tuple[bool, str | None]: (success, error_message)
         - success: True if operation succeeded
         - error_message: None on success, error string on failure
         - On Linux: Returns (False, "DLSS overlay is only available on Windows")
@@ -77,7 +76,7 @@ async def set_dlss_overlay_state(enabled: bool) -> Tuple[bool, Optional[str]]:
     if not IS_WINDOWS:
         return (False, "DLSS overlay is only available on Windows")
 
-    def _write_registry() -> Tuple[bool, Optional[str]]:
+    def _write_registry() -> tuple[bool, str | None]:
         import winreg
 
         try:

--- a/dlss_updater/steam_integration.py
+++ b/dlss_updater/steam_integration.py
@@ -8,7 +8,6 @@ import re
 import threading
 import msgspec
 from pathlib import Path
-from typing import Optional, List
 from datetime import datetime, timedelta
 import aiohttp
 
@@ -159,7 +158,7 @@ class SteamIntegration:
                             else:
                                 logger.warning(f"Unexpected format from {url}")
 
-                    except asyncio.TimeoutError:
+                    except TimeoutError:
                         logger.warning(f"Timeout downloading {url}")
                         continue
                     except Exception as e:
@@ -245,7 +244,7 @@ class SteamIntegration:
 
         return normalized
 
-    async def find_steam_app_id_by_name(self, game_name: str) -> Optional[int]:
+    async def find_steam_app_id_by_name(self, game_name: str) -> int | None:
         """
         Find Steam app ID by game name using database-backed FTS5 search.
 
@@ -288,7 +287,7 @@ class SteamIntegration:
             logger.error(f"Error finding Steam app ID for '{game_name}': {e}", exc_info=True)
             return None
 
-    async def search_steam_apps(self, query: str, limit: int = 10) -> List[tuple[int, str]]:
+    async def search_steam_apps(self, query: str, limit: int = 10) -> list[tuple[int, str]]:
         """
         Search Steam apps by name using FTS5 full-text search.
 
@@ -307,7 +306,7 @@ class SteamIntegration:
             logger.error(f"Error searching Steam apps: {e}", exc_info=True)
             return []
 
-    async def detect_steam_app_id_from_manifest(self, game_dir: Path) -> Optional[int]:
+    async def detect_steam_app_id_from_manifest(self, game_dir: Path) -> int | None:
         """
         Detect Steam app ID from appmanifest files (for Steam launcher games)
         This is faster and more accurate than name matching
@@ -360,7 +359,7 @@ class SteamIntegration:
             logger.error(f"Error detecting Steam app ID from manifest for {game_dir}: {e}", exc_info=True)
             return None
 
-    async def fetch_steam_header_image(self, app_id: int) -> Optional[Path]:
+    async def fetch_steam_header_image(self, app_id: int) -> Path | None:
         """
         Fetch Steam game header image and save as optimized WebP thumbnail.
 
@@ -424,7 +423,7 @@ class SteamIntegration:
                                     logger.debug(f"Image not found (404) for app {app_id} at {url}")
                                     continue
 
-                        except asyncio.TimeoutError:
+                        except TimeoutError:
                             logger.debug(f"Timeout fetching image from {url}")
                             continue
                         except Exception as e:
@@ -440,7 +439,7 @@ class SteamIntegration:
             logger.error(f"Error fetching Steam image for app {app_id}: {e}", exc_info=True)
             return None
 
-    async def queue_image_downloads(self, app_ids: List[int]):
+    async def queue_image_downloads(self, app_ids: list[int]):
         """
         Queue multiple image downloads with concurrency control
 
@@ -466,17 +465,17 @@ async def update_steam_app_list_if_needed():
     await steam_integration.update_app_list_if_needed()
 
 
-async def find_steam_app_id_by_name(game_name: str) -> Optional[int]:
+async def find_steam_app_id_by_name(game_name: str) -> int | None:
     """Find Steam app ID by game name"""
     return await steam_integration.find_steam_app_id_by_name(game_name)
 
 
-async def detect_steam_app_id_from_manifest(game_dir: Path) -> Optional[int]:
+async def detect_steam_app_id_from_manifest(game_dir: Path) -> int | None:
     """Detect Steam app ID from appmanifest files"""
     return await steam_integration.detect_steam_app_id_from_manifest(game_dir)
 
 
-async def fetch_steam_image(app_id: int) -> Optional[Path]:
+async def fetch_steam_image(app_id: int) -> Path | None:
     """Fetch Steam header image"""
     return await steam_integration.fetch_steam_header_image(app_id)
 
@@ -493,12 +492,12 @@ async def migrate_image_cache_if_needed() -> bool:
     return await steam_integration.migrate_image_cache()
 
 
-async def queue_image_downloads(app_ids: List[int]):
+async def queue_image_downloads(app_ids: list[int]):
     """Queue multiple image downloads"""
     await steam_integration.queue_image_downloads(app_ids)
 
 
-async def search_steam_apps(query: str, limit: int = 10) -> List[tuple[int, str]]:
+async def search_steam_apps(query: str, limit: int = 10) -> list[tuple[int, str]]:
     """
     Search Steam apps by name using FTS5 full-text search.
 

--- a/dlss_updater/ui_flet/async_updater.py
+++ b/dlss_updater/ui_flet/async_updater.py
@@ -6,7 +6,7 @@ Bridges Flet UI with existing scanner/updater modules using async patterns
 import asyncio
 import logging
 from pathlib import Path
-from typing import Callable, Optional, Dict, List, Any
+from typing import Callable, Any
 
 from dlss_updater.scanner import find_all_dlls
 from dlss_updater.utils import update_dlss_versions, process_single_dll
@@ -22,13 +22,13 @@ class AsyncUpdateCoordinator:
 
     def __init__(self, logger: logging.Logger):
         self.logger = logger
-        self._progress_callback: Optional[Callable] = None
+        self._progress_callback: Callable | None = None
         self._cancel_requested = False
 
     async def scan_for_games(
         self,
-        progress_callback: Optional[Callable[[UpdateProgress], None]] = None
-    ) -> Dict[str, List]:
+        progress_callback: Callable[[UpdateProgress], None] | None = None
+    ) -> dict[str, list]:
         """
         Scan all configured launchers for games with DLLs
 
@@ -74,8 +74,8 @@ class AsyncUpdateCoordinator:
 
     async def update_games(
         self,
-        dll_dict: Dict[str, List],
-        progress_callback: Optional[Callable[[UpdateProgress], None]] = None
+        dll_dict: dict[str, list],
+        progress_callback: Callable[[UpdateProgress], None] | None = None
     ) -> UpdateResult:
         """
         Update DLLs for discovered games
@@ -243,7 +243,7 @@ class AsyncUpdateCoordinator:
 
     async def scan_and_update(
         self,
-        progress_callback: Optional[Callable[[UpdateProgress], None]] = None
+        progress_callback: Callable[[UpdateProgress], None] | None = None
     ) -> UpdateResult:
         """
         Convenience method: scan then update in one operation
@@ -296,9 +296,9 @@ class AsyncUpdateCoordinator:
         self,
         game_id: int,
         game_name: str,
-        dll_groups: Optional[List[str]] = None,
-        progress_callback: Optional[Callable[[UpdateProgress], None]] = None
-    ) -> Dict[str, Any]:
+        dll_groups: list[str] | None = None,
+        progress_callback: Callable[[UpdateProgress], None] | None = None
+    ) -> dict[str, Any]:
         """
         Update DLLs for a single game
 
@@ -316,7 +316,7 @@ class AsyncUpdateCoordinator:
         self.logger.info(f"Starting single-game update for: {game_name} (id: {game_id}, groups: {groups_str})")
         self._progress_callback = progress_callback
 
-        results: Dict[str, Any] = {
+        results: dict[str, Any] = {
             'updated': [],
             'skipped': [],
             'errors': [],

--- a/dlss_updater/ui_flet/components/app_menu_selector.py
+++ b/dlss_updater/ui_flet/components/app_menu_selector.py
@@ -6,7 +6,7 @@ Features colored icon circles, hover effects, and smooth animations.
 """
 
 from dataclasses import dataclass, field
-from typing import Callable, Optional, List, Dict
+from typing import Callable
 
 import flet as ft
 
@@ -20,10 +20,10 @@ class MenuItem:
     title: str
     description: str
     icon: str
-    on_click: Optional[Callable] = None
+    on_click: Callable | None = None
     is_disabled: bool = False
     show_badge: bool = False
-    tooltip: Optional[str] = None
+    tooltip: str | None = None
 
 
 @dataclass
@@ -33,7 +33,7 @@ class MenuCategory:
     title: str
     icon: str
     color: str  # Hex color for the category
-    items: List[MenuItem] = field(default_factory=list)
+    items: list[MenuItem] = field(default_factory=list)
 
 
 class AppMenuSelector(ft.Container):
@@ -47,8 +47,8 @@ class AppMenuSelector(ft.Container):
     def __init__(
         self,
         page: ft.Page,
-        categories: List[MenuCategory],
-        on_item_selected: Optional[Callable[[str], None]] = None,
+        categories: list[MenuCategory],
+        on_item_selected: Callable[[str], None] | None = None,
         initially_expanded: bool = False,
         is_dark: bool = True,
     ):
@@ -58,13 +58,13 @@ class AppMenuSelector(ft.Container):
         self.on_item_selected = on_item_selected
         self.is_expanded = initially_expanded
         self._is_dark = is_dark
-        self.selected_item_id: Optional[str] = None
+        self.selected_item_id: str | None = None
 
         # Badge references for dynamic updates
-        self._badge_refs: Dict[str, ft.Container] = {}
+        self._badge_refs: dict[str, ft.Container] = {}
 
         # Item container refs for hover effects
-        self._item_refs: Dict[str, ft.Container] = {}
+        self._item_refs: dict[str, ft.Container] = {}
 
         # Build the component
         self._build()

--- a/dlss_updater/ui_flet/components/game_card.py
+++ b/dlss_updater/ui_flet/components/game_card.py
@@ -5,7 +5,7 @@ Individual game card with Steam image, DLL badges, and action buttons
 
 import asyncio
 from pathlib import Path
-from typing import Optional, List, Dict
+from typing import Callable, Any
 import flet as ft
 
 from dlss_updater.database import GameDLL
@@ -18,7 +18,7 @@ from dlss_updater.constants import DLL_GROUPS
 class GameCard(ft.Card):
     """Individual game card with image, DLL info, and actions"""
 
-    def __init__(self, game, dlls: List[GameDLL], page: ft.Page, logger, on_update=None, on_view_backups=None, on_restore=None, backup_groups: Optional[Dict[str, List]] = None):
+    def __init__(self, game, dlls: list[GameDLL], page: ft.Page, logger, on_update=None, on_view_backups=None, on_restore=None, backup_groups: dict[str, list] | None = None):
         super().__init__()
         self.game = game
         self.dlls = dlls
@@ -31,13 +31,13 @@ class GameCard(ft.Card):
         self.has_backups = bool(backup_groups)
 
         # Button references for loading state
-        self.update_button: Optional[ft.PopupMenuButton] = None
-        self.restore_button: Optional[ft.PopupMenuButton] = None
+        self.update_button: ft.PopupMenuButton | None = None
+        self.restore_button: ft.PopupMenuButton | None = None
         self.is_updating = False
 
         # Reference to dll_badges for refresh
-        self.dll_badges_container: Optional[ft.Container] = None
-        self.right_content: Optional[ft.Column] = None
+        self.dll_badges_container: ft.Container | None = None
+        self.right_content: ft.Column | None = None
 
         # Async lock for UI updates to prevent race conditions
         self._ui_lock = asyncio.Lock()
@@ -113,7 +113,7 @@ class GameCard(ft.Card):
                 continue
         return False
 
-    def _build_dll_popover_items(self) -> List[ft.PopupMenuItem]:
+    def _build_dll_popover_items(self) -> list[ft.PopupMenuItem]:
         """Build popup menu items for all DLLs with color coding and update status"""
         from dlss_updater.config import LATEST_DLL_VERSIONS
         from dlss_updater.updater import parse_version
@@ -327,7 +327,7 @@ class GameCard(ft.Card):
             height=28,
         )
 
-    def _get_dll_groups_for_game(self) -> List[str]:
+    def _get_dll_groups_for_game(self) -> list[str]:
         """Get unique DLL technology groups present in this game"""
         groups_present = set()
         for dll in self.dlls:
@@ -565,7 +565,7 @@ class GameCard(ft.Card):
             self.update_button.disabled = is_updating
             self.update_button.update()
 
-    async def refresh_dlls(self, new_dlls: List[GameDLL]):
+    async def refresh_dlls(self, new_dlls: list[GameDLL]):
         """Refresh DLL badges with new data after update (async for UI lock)"""
         async with self._ui_lock:
             self.dlls = new_dlls
@@ -579,7 +579,7 @@ class GameCard(ft.Card):
                 self.dll_badges_container = new_badges
                 self.right_content.update()
 
-    async def refresh_restore_button(self, new_backup_groups: Dict[str, List]):
+    async def refresh_restore_button(self, new_backup_groups: dict[str, list]):
         """Refresh restore button with new backup data after restore"""
         async with self._ui_lock:
             self.backup_groups = new_backup_groups

--- a/dlss_updater/ui_flet/components/launcher_card.py
+++ b/dlss_updater/ui_flet/components/launcher_card.py
@@ -6,7 +6,7 @@ Expandable card showing launcher configuration and detected games using Material
 import logging
 import subprocess
 from pathlib import Path
-from typing import Optional, Callable, List, Dict
+from typing import Callable, Any
 
 import flet as ft
 
@@ -43,9 +43,9 @@ class LauncherCard(ft.ExpansionTile):
         self.logger = logger
 
         # State - multi-path support
-        self.current_paths: List[str] = []  # List of configured paths
+        self.current_paths: list[str] = []  # List of configured paths
         self.games_count: int = 0
-        self.games_data: List[Dict] = []  # List of detected games
+        self.games_data: list[dict] = []  # List of detected games
 
         # Get theme state
         is_dark = page.session.get("is_dark_theme") if page and page.session.contains_key("is_dark_theme") else True
@@ -376,7 +376,7 @@ class LauncherCard(ft.ExpansionTile):
         if self.page:
             self.page.update()
 
-    async def set_paths(self, paths: List[str]):
+    async def set_paths(self, paths: list[str]):
         """
         Update the launcher paths (multi-path support).
 
@@ -420,7 +420,7 @@ class LauncherCard(ft.ExpansionTile):
         else:
             await self.set_paths([])
 
-    async def set_games(self, games_data: List[Dict]):
+    async def set_games(self, games_data: list[dict]):
         """
         Update the game list for this launcher
 

--- a/dlss_updater/ui_flet/components/logger_panel.py
+++ b/dlss_updater/ui_flet/components/logger_panel.py
@@ -7,7 +7,7 @@ Thread-safe implementation using page.run_task()
 import logging
 import asyncio
 import threading
-from typing import Optional, List
+from typing import Callable, Any
 import flet as ft
 from dlss_updater.ui_flet.theme.colors import MD3Colors, Animations, Shadows
 
@@ -294,7 +294,7 @@ class LoggerPanel(ft.Container):
         self.shadow = Shadows.LEVEL_2
         self.border_radius = 0  # Bottom panel, no radius
 
-    def _create_filter_chips(self) -> List[ft.Container]:
+    def _create_filter_chips(self) -> list[ft.Container]:
         """Create filter chips for log levels"""
         levels = ["ALL", "DEBUG", "INFO", "WARNING", "ERROR"]
         chips = []

--- a/dlss_updater/ui_flet/components/search_bar.py
+++ b/dlss_updater/ui_flet/components/search_bar.py
@@ -11,7 +11,7 @@ Thread-safe for free-threaded Python 3.14+.
 """
 
 import asyncio
-from typing import Callable, List, Optional, Dict, Any, Union
+from typing import Callable, Any
 import flet as ft
 
 from dlss_updater.logger import setup_logger
@@ -49,12 +49,12 @@ class SearchBar(ft.Container):
 
     def __init__(
         self,
-        on_search: Optional[Callable[[str], None]] = None,
-        on_clear: Optional[Callable[[], None]] = None,
-        on_history_selected: Optional[Callable[[str], None]] = None,
-        on_focus_change: Optional[Callable[[bool], None]] = None,
+        on_search: Callable[[str], None] | None = None,
+        on_clear: Callable[[], None] | None = None,
+        on_history_selected: Callable[[str], None] | None = None,
+        on_focus_change: Callable[[bool], None] | None = None,
         placeholder: str = "Search games...",
-        width: Optional[int] = None,
+        width: int | None = None,
     ):
         super().__init__()
         self.on_search_callback = on_search
@@ -66,8 +66,8 @@ class SearchBar(ft.Container):
 
         # State
         self._is_focused = False
-        self._history_items: List[Any] = []
-        self._debounce_task: Optional[asyncio.Task] = None
+        self._history_items: list[Any] = []
+        self._debounce_task: asyncio.Task | None = None
 
         # Build UI
         self._build_ui()
@@ -234,7 +234,7 @@ class SearchBar(ft.Container):
             if asyncio.iscoroutine(result):
                 await result
 
-    def update_history(self, history_items: List[Any]):
+    def update_history(self, history_items: list[Any]):
         """
         Update search history popup menu items.
 

--- a/dlss_updater/ui_flet/dialogs/app_update_dialog.py
+++ b/dlss_updater/ui_flet/dialogs/app_update_dialog.py
@@ -16,11 +16,12 @@ def _open_url(url: str) -> bool:
     """Open a URL in the default browser (cross-platform)."""
     import sys
     import os
+    from pathlib import Path
 
     # On Linux (including WSL2), try multiple methods
     if sys.platform == 'linux':
         # Check if running in WSL
-        is_wsl = 'microsoft' in os.uname().release.lower() or os.path.exists('/mnt/c/Windows')
+        is_wsl = 'microsoft' in os.uname().release.lower() or Path('/mnt/c/Windows').exists()
 
         if is_wsl:
             # In WSL2, use cmd.exe to open URL in Windows browser

--- a/dlss_updater/ui_flet/dialogs/high_perf_warning_dialog.py
+++ b/dlss_updater/ui_flet/dialogs/high_perf_warning_dialog.py
@@ -5,7 +5,7 @@ Shows warning and system info when user enables high-performance mode
 
 import asyncio
 import logging
-from typing import Optional
+from typing import Callable, Any
 
 import flet as ft
 import psutil
@@ -30,8 +30,8 @@ class HighPerfWarningDialog:
         self.page = page
         self.logger = logger
         self._confirmed = False
-        self._dialog: Optional[ft.AlertDialog] = None
-        self._close_event: Optional[asyncio.Event] = None
+        self._dialog: ft.AlertDialog | None = None
+        self._close_event: asyncio.Event | None = None
 
     def _get_memory_stats(self) -> tuple[float, float, float]:
         """

--- a/dlss_updater/ui_flet/theme/md3_system.py
+++ b/dlss_updater/ui_flet/theme/md3_system.py
@@ -5,7 +5,7 @@ Based on Material Design 3 specifications and DLSS Updater UX proposal.
 """
 
 import flet as ft
-from typing import Dict, List, Optional, Union
+from typing import Callable, Any
 
 
 class MD3ColorSystem:
@@ -305,7 +305,7 @@ class MD3Typography:
     )
 
     @classmethod
-    def get_text_style(cls, variant: str, color: Optional[str] = None) -> ft.TextStyle:
+    def get_text_style(cls, variant: str, color: str | None = None) -> ft.TextStyle:
         """Get text style by variant name with optional color override"""
         style_map = {
             'display_large': cls.DISPLAY_LARGE,
@@ -561,7 +561,7 @@ class MD3Spacing:
 
     # ==================== HELPER METHODS ====================
     @classmethod
-    def spacing(cls, multiplier: Union[int, float]) -> int:
+    def spacing(cls, multiplier: int | float) -> int:
         """Get spacing based on base unit multiplier"""
         return int(cls.BASE_UNIT * multiplier)
 
@@ -671,7 +671,7 @@ class MD3Shadows:
 
     # ==================== BRAND-COLORED SHADOWS ====================
     @classmethod
-    def brand_shadow(cls, color: str, elevation: int = 2) -> List[ft.BoxShadow]:
+    def brand_shadow(cls, color: str, elevation: int = 2) -> list[ft.BoxShadow]:
         """Create brand-colored shadow with specified elevation"""
         base_shadows = {
             1: [(0, 1, 2, 0.12)],
@@ -713,15 +713,15 @@ class MD3Shadows:
 
 def create_md3_container(
     content: ft.Control,
-    bgcolor: Optional[str] = None,
-    padding: Union[int, ft.Padding] = MD3Spacing.PADDING_MEDIUM,
+    bgcolor: str | None = None,
+    padding: int | ft.Padding = MD3Spacing.PADDING_MEDIUM,
     border_radius: int = MD3Spacing.RADIUS_MEDIUM,
-    shadow: Optional[Union[ft.BoxShadow, List[ft.BoxShadow]]] = MD3Shadows.LEVEL_2,
-    border: Optional[ft.Border] = None,
-    width: Optional[int] = None,
-    height: Optional[int] = None,
-    expand: Union[bool, int] = False,
-    animate: Optional[ft.Animation] = None,
+    shadow: ft.BoxShadow | list[ft.BoxShadow] | None = MD3Shadows.LEVEL_2,
+    border: ft.Border | None = None,
+    width: int | None = None,
+    height: int | None = None,
+    expand: bool | int = False,
+    animate: ft.Animation | None = None,
 ) -> ft.Container:
     """
     Create MD3-styled container with sensible defaults
@@ -767,8 +767,8 @@ def create_md3_card(
     on_hover=None,
     elevation: int = 2,
     interactive: bool = False,
-    width: Optional[int] = None,
-    height: Optional[int] = None,
+    width: int | None = None,
+    height: int | None = None,
 ) -> ft.Container:
     """
     Create MD3-styled interactive card
@@ -812,9 +812,9 @@ def create_md3_button(
     text: str,
     on_click=None,
     style: str = "filled",  # filled, outlined, text, elevated, tonal
-    icon: Optional[str] = None,
+    icon: str | None = None,
     disabled: bool = False,
-    width: Optional[int] = None,
+    width: int | None = None,
     height: int = MD3Spacing.BUTTON_HEIGHT_MEDIUM,
 ) -> ft.ElevatedButton:
     """
@@ -886,10 +886,10 @@ def create_md3_button(
 def create_md3_text(
     text: str,
     variant: str = "body_medium",
-    color: Optional[str] = None,
+    color: str | None = None,
     selectable: bool = False,
     text_align: ft.TextAlign = ft.TextAlign.LEFT,
-    max_lines: Optional[int] = None,
+    max_lines: int | None = None,
     overflow: ft.TextOverflow = ft.TextOverflow.FADE,
 ) -> ft.Text:
     """
@@ -925,9 +925,9 @@ def create_md3_text(
 def create_md3_icon_button(
     icon: str,
     on_click=None,
-    icon_color: Optional[str] = None,
-    bgcolor: Optional[str] = None,
-    tooltip: Optional[str] = None,
+    icon_color: str | None = None,
+    bgcolor: str | None = None,
+    tooltip: str | None = None,
     size: int = MD3Spacing.ICON_BUTTON_SIZE_MEDIUM,
     icon_size: int = MD3Spacing.ICON_SIZE_MEDIUM,
 ) -> ft.IconButton:

--- a/dlss_updater/ui_flet/views/backups_view.py
+++ b/dlss_updater/ui_flet/views/backups_view.py
@@ -4,7 +4,7 @@ Backups View - Browse and restore DLL backups
 
 import asyncio
 import math
-from typing import List, Optional
+from typing import Callable, Any
 import flet as ft
 
 from dlss_updater.database import db_manager, DLLBackup
@@ -25,17 +25,17 @@ class BackupsView(ft.Column):
         self.spacing = 0
 
         # State
-        self.backups: List[GameDLLBackup] = []
+        self.backups: list[GameDLLBackup] = []
         self.is_loading = False
         self.refresh_button_ref = ft.Ref[ft.IconButton]()
 
         # Button references for state management
-        self.clear_all_button: Optional[ft.ElevatedButton] = None
+        self.clear_all_button: ft.ElevatedButton | None = None
 
         # Game filter state
-        self.selected_game_id: Optional[int] = None
-        self.game_filter_dropdown: Optional[ft.Dropdown] = None
-        self.games_with_backups: List[GameWithBackupCount] = []
+        self.selected_game_id: int | None = None
+        self.game_filter_dropdown: ft.Dropdown | None = None
+        self.games_with_backups: list[GameWithBackupCount] = []
 
         # Build initial UI
         self._build_ui()
@@ -114,7 +114,7 @@ class BackupsView(ft.Column):
                 self.selected_game_id = None
                 self.game_filter_dropdown.value = "all"
 
-    def set_game_filter(self, game_id: Optional[int]):
+    def set_game_filter(self, game_id: int | None):
         """Set game filter programmatically (for navigation from Games view)"""
         self.selected_game_id = game_id
         if self.game_filter_dropdown:

--- a/dlss_updater/ui_flet/views/games_view.py
+++ b/dlss_updater/ui_flet/views/games_view.py
@@ -4,7 +4,7 @@ Games View - Display all games organized by launcher with Steam images
 
 import asyncio
 import math
-from typing import Dict, List, Optional, Any
+from typing import Callable, Any
 import flet as ft
 
 from dlss_updater.database import db_manager, Game
@@ -27,22 +27,22 @@ class GamesView(ft.Column):
         self.spacing = 0
 
         # State
-        self.games_by_launcher: Dict[str, List[Game]] = {}
+        self.games_by_launcher: dict[str, list[Game]] = {}
         self.is_loading = False
         self.refresh_button_ref = ft.Ref[ft.IconButton]()
 
         # Game card tracking for single-game updates
-        self.game_cards: Dict[int, GameCard] = {}  # game_id -> GameCard
-        self.game_card_containers: Dict[int, ft.Container] = {}  # game_id -> container wrapper
-        self.update_coordinator: Optional[AsyncUpdateCoordinator] = None
+        self.game_cards: dict[int, GameCard] = {}  # game_id -> GameCard
+        self.game_card_containers: dict[int, ft.Container] = {}  # game_id -> container wrapper
+        self.update_coordinator: AsyncUpdateCoordinator | None = None
 
         # Button references for state management
-        self.delete_db_button: Optional[ft.ElevatedButton] = None
+        self.delete_db_button: ft.ElevatedButton | None = None
 
         # Search state
         self.search_query: str = ""
         self._search_generation: int = 0
-        self.search_bar: Optional[SearchBar] = None
+        self.search_bar: SearchBar | None = None
 
         # Build initial UI
         self._build_ui()
@@ -349,7 +349,7 @@ class GamesView(ft.Column):
         else:
             await self._show_all_games()
 
-    async def _animate_cards_in(self, game_cards: List[GameCard]):
+    async def _animate_cards_in(self, game_cards: list[GameCard]):
         """Animate game cards with staggered fade-in for grid layout"""
         # Small initial delay
         await asyncio.sleep(0.1)
@@ -460,7 +460,7 @@ class GamesView(ft.Column):
         if self.page:
             self.page.update()
 
-    def _get_current_launcher(self) -> Optional[str]:
+    def _get_current_launcher(self) -> str | None:
         """Get the currently selected launcher tab."""
         if not hasattr(self, 'tabs_control') or not self.tabs_control:
             return None
@@ -735,7 +735,7 @@ class GamesView(ft.Column):
         if self.page:
             self.page.update()
 
-    async def _show_update_results_dialog(self, game_name: str, result: Dict[str, Any]):
+    async def _show_update_results_dialog(self, game_name: str, result: dict[str, Any]):
         """Show results dialog after single-game update"""
         # Build result content
         content_controls = []

--- a/dlss_updater/ui_flet/views/main_view.py
+++ b/dlss_updater/ui_flet/views/main_view.py
@@ -9,7 +9,7 @@ import subprocess
 import webbrowser
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Dict, List
+from typing import Callable, Any
 
 import flet as ft
 
@@ -30,7 +30,7 @@ def open_url(url: str) -> bool:
     # On Linux (including WSL2), try multiple methods
     if sys.platform == 'linux':
         # Check if running in WSL by looking for Windows interop
-        is_wsl = 'microsoft' in os.uname().release.lower() or os.path.exists('/mnt/c/Windows')
+        is_wsl = 'microsoft' in os.uname().release.lower() or Path('/mnt/c/Windows').exists()
 
         if is_wsl:
             # In WSL2, use cmd.exe to open URL in Windows browser
@@ -101,14 +101,14 @@ class MainView(ft.Column):
 
         # File picker for launcher paths
         self.file_picker = ft.FilePicker(on_result=self._on_folder_selected)
-        self.current_launcher_selecting: Optional[LauncherPathName] = None
+        self.current_launcher_selecting: LauncherPathName | None = None
         self.is_adding_subfolder: bool = False  # Track if adding subfolder vs setting primary path
 
         # Loading overlay
         self.loading_overlay = LoadingOverlay()
 
         # Launcher cards dictionary
-        self.launcher_cards: Dict[LauncherPathName, LauncherCard] = {}
+        self.launcher_cards: dict[LauncherPathName, LauncherCard] = {}
 
         # Async update coordinator
         self.update_coordinator = AsyncUpdateCoordinator(logger)
@@ -121,22 +121,22 @@ class MainView(ft.Column):
         self.theme_toggle_btn = None  # Will be created in _create_app_bar
 
         # DLL cache progress snackbar
-        self.dll_cache_snackbar: Optional[DLLCacheProgressSnackbar] = None
+        self.dll_cache_snackbar: DLLCacheProgressSnackbar | None = None
 
         # Menu state
         self.menu_expanded = False
         self.app_menu_selector = None  # Will be created in _create_app_bar
 
         # Discord banner
-        self.discord_banner: Optional[ft.Banner] = None
+        self.discord_banner: ft.Banner | None = None
 
         # Navigation state
         self.current_view_index = 0  # 0=Launchers, 1=Games, 2=Backups
         self.last_view_index = 0  # Track previous view for cleanup
 
         # Scan state management - store last scan results for update operations
-        self.last_scan_results: Optional[Dict] = None
-        self.last_scan_timestamp: Optional[str] = None
+        self.last_scan_results: dict | None = None
+        self.last_scan_timestamp: str | None = None
         self.scan_cache_path = Path(get_config_path()).parent / "scan_cache.json"
 
         # View instances (will be created in _build_ui)
@@ -1259,7 +1259,7 @@ class MainView(ft.Column):
             )
             self.page.open(error_dialog)
 
-    async def _populate_launcher_cards(self, dll_dict: Dict):
+    async def _populate_launcher_cards(self, dll_dict: dict):
         """
         Populate launcher cards with game data from scan results
 

--- a/dlss_updater/utils.py
+++ b/dlss_updater/utils.py
@@ -2,7 +2,6 @@ import os
 import asyncio
 import concurrent.futures
 import threading
-from typing import List, Tuple, Dict, Optional
 import sys
 from pathlib import Path
 from dlss_updater.logger import setup_logger
@@ -210,26 +209,24 @@ except ImportError as e:
 def find_file_in_directory(directory, filename):
     for root, _, files in os.walk(directory):
         if filename in files:
-            return os.path.join(root, filename)
+            return str(Path(root) / filename)
     return None
 
 
 def check_update_completion():
-    update_log_path = os.path.join(os.path.dirname(sys.executable), "update_log.txt")
-    if os.path.exists(update_log_path):
+    update_log_path = Path(sys.executable).parent / "update_log.txt"
+    if update_log_path.exists():
         with open(update_log_path, "r") as f:
             logger.info(f"Update completed: {f.read()}")
-        os.remove(update_log_path)
+        update_log_path.unlink()
 
 
 def check_update_error():
-    error_log_path = os.path.join(
-        os.path.dirname(sys.executable), "update_error_log.txt"
-    )
-    if os.path.exists(error_log_path):
+    error_log_path = Path(sys.executable).parent / "update_error_log.txt"
+    if error_log_path.exists():
         with open(error_log_path, "r") as f:
             logger.error(f"Update error occurred: {f.read()}")
-        os.remove(error_log_path)
+        error_log_path.unlink()
 
 
 def check_dependencies():

--- a/dlss_updater/vdf_parser.py
+++ b/dlss_updater/vdf_parser.py
@@ -11,7 +11,7 @@ Uses pre-compiled regex for O(1) key-value extraction and aiofiles for async I/O
 import re
 import asyncio
 from pathlib import Path
-from typing import Dict, List, Optional, Any
+from typing import Any
 
 import aiofiles
 
@@ -37,7 +37,7 @@ class VDFParser:
     _BLOCK_START = re.compile(r'"([^"]+)"\s*$')
 
     @classmethod
-    async def parse_file(cls, file_path: Path, encoding: str = 'utf-8') -> Dict[str, Any]:
+    async def parse_file(cls, file_path: Path, encoding: str = 'utf-8') -> dict[str, Any]:
         """
         Parse a VDF file and return its contents as a nested dictionary.
 
@@ -58,7 +58,7 @@ class VDFParser:
             return {}
 
     @classmethod
-    def _parse_vdf_content(cls, content: str) -> Dict[str, Any]:
+    def _parse_vdf_content(cls, content: str) -> dict[str, Any]:
         """
         Parse VDF content string into nested dictionary.
 
@@ -104,7 +104,7 @@ class VDFParser:
         return result
 
     @classmethod
-    async def parse_library_folders(cls, vdf_path: Path) -> List[Path]:
+    async def parse_library_folders(cls, vdf_path: Path) -> list[Path]:
         """
         Parse libraryfolders.vdf to extract all Steam library paths.
 
@@ -149,7 +149,7 @@ class VDFParser:
         return libraries
 
     @classmethod
-    async def parse_appmanifest(cls, acf_path: Path) -> Optional[Dict[str, str]]:
+    async def parse_appmanifest(cls, acf_path: Path) -> dict[str, str] | None:
         """
         Parse appmanifest_*.acf to extract game metadata.
 
@@ -192,7 +192,7 @@ class VDFParser:
             return None
 
     @classmethod
-    async def enumerate_steam_games(cls, steam_path: Path) -> List[Dict[str, Any]]:
+    async def enumerate_steam_games(cls, steam_path: Path) -> list[dict[str, Any]]:
         """
         Enumerate all installed Steam games using appmanifest files.
 
@@ -224,7 +224,7 @@ class VDFParser:
             return games
 
         # Process all libraries in parallel
-        async def process_library(steamapps_dir: Path) -> List[Dict[str, Any]]:
+        async def process_library(steamapps_dir: Path) -> list[dict[str, Any]]:
             library_games = []
 
             # Find all appmanifest files

--- a/dlss_updater/whitelist.py
+++ b/dlss_updater/whitelist.py
@@ -1,7 +1,7 @@
-import os
 import csv
 import threading
 from io import StringIO
+from pathlib import Path
 import asyncio
 import aiohttp
 from dlss_updater.logger import setup_logger
@@ -46,7 +46,7 @@ async def fetch_whitelist_async() -> set:
                 reader = csv.reader(csv_data)
                 return set(row[0].strip() for row in reader if row and row[0].strip())
 
-    except asyncio.TimeoutError:
+    except TimeoutError:
         logger.error("Timeout fetching whitelist")
         return set()
     except aiohttp.ClientError as e:
@@ -124,8 +124,8 @@ async def is_whitelisted(game_path):
     # Get the whitelist (will initialize if needed)
     whitelist = await get_whitelist()
 
-    # Extract path components
-    path_parts = [p for p in game_path.split(os.path.sep) if p]
+    # Extract path components using pathlib
+    path_parts = list(Path(game_path).parts)
 
     # Skip if the path is too short
     if len(path_parts) < 3:


### PR DESCRIPTION
- Removes the use of `asyncio.iscoroutinefunction`.
- Fixes some model areas to be compliant.
- Migration to `Path` calls that 3.14 uses.
- Some minor performance increases as a bi-product.