### PR TITLE
fix: don't persist minimized window position

### DIFF
--- a/dlss_updater/config.py
+++ b/dlss_updater/config.py
@@ -1238,9 +1238,13 @@ class ConfigManager:
             ws = self._config.window_state
             ws.width = int(width)
             ws.height = int(height)
-            ws.has_position = top is not None and left is not None
-            ws.top = int(top) if top is not None else 0
-            ws.left = int(left) if left is not None else 0
+            # A minimized window reports the off-screen sentinel (-32000 on
+            # Windows). Persisting it would hide the window on next launch,
+            # so keep the last visible position instead.
+            if top is not None and left is not None and top > -10000 and left > -10000:
+                ws.has_position = True
+                ws.top = int(top)
+                ws.left = int(left)
             ws.maximized = bool(maximized)
             self._save_unlocked()
 

--- a/main.py
+++ b/main.py
@@ -180,9 +180,13 @@ async def main(page: ft.Page):
     _saved_window = config_manager.get_window_state()
     page.window.width = max(_saved_window["width"], 820)
     page.window.height = max(_saved_window["height"], 560)
-    if _saved_window["top"] is not None and _saved_window["left"] is not None:
-        page.window.top = _saved_window["top"]
-        page.window.left = _saved_window["left"]
+    top = _saved_window["top"]
+    left = _saved_window["left"]
+    # Ignore the minimized-window sentinel (-32000 on Windows) that older
+    # versions may have persisted; the OS centers the window instead.
+    if top is not None and left is not None and top > -10000 and left > -10000:
+        page.window.top = top
+        page.window.left = left
     if _saved_window["maximized"]:
         page.window.maximized = True
 


### PR DESCRIPTION
Sometimes the program opens but the window doesn't show up anywhere. The icon is in the taskbar and alt+tab but it's impossible to click or open anything, and I have to delete the whole data folder to make it work again.

I looked at my config.toml and found this:

[window_state]
top = -32000
left = -32000

Looks like it saves the position while minimized and then restores it off screen on the next launch. This PR skips saving the position in that case.

Simply the DU, keeps in the background and cantt open this, my solution in many cases was delete the db files and all data :/